### PR TITLE
[Fix] for #94 Fix detection of .text section failure if .text is not the first section with non-blank fullname.

### DIFF
--- a/unlicense/dump_utils.py
+++ b/unlicense/dump_utils.py
@@ -46,7 +46,7 @@ def probe_text_sections(pe_file_path: str) -> Optional[List[MemoryRange]]:
         stripped_section_name = section_name.replace(' ',
                                                      '').replace('\00', '')
         if len(stripped_section_name) > 0 and stripped_section_name != ".text":
-            break
+            continue
 
         if section.has_characteristic(
                 lief.PE.SECTION_CHARACTERISTICS.MEM_EXECUTE):


### PR DESCRIPTION
For example, in some binary `.textbss` is the first section of PE file, and this would cause an error like that.
`ERROR - Failed to automatically detect .text section`.


This would fix #94 